### PR TITLE
Trailing newlines are important

### DIFF
--- a/colornetstat
+++ b/colornetstat
@@ -9,3 +9,4 @@ color_cyan=`echo "33[1;36m"`
 no_color=`echo "33[0m"`
 
 netstat ${@} |sed -e "s/^.* ESTABLISH.*$/${color_green}&${no_color}/; s/^.* LIST.*$/${color_cyan}&${no_color}/; s/^.* *.WAIT$/${color_red}&${no_color}/; s/^.* CLOSING$/${color_red}&${no_color}/; s/^.* SYN.*$/${color_yellow}&${no_color}/; s/^.* FIN.*$/${color_yellow}&${no_color}/; s/^.* *.ACK/${color_yellow}&${no_color}/"
+


### PR DESCRIPTION
- Newlines make files more compliant
- Our parser can now read this right
- OCD
