### PR TITLE
Add missing arg error and usage output

### DIFF
--- a/git-graphlive
+++ b/git-graphlive
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+#Ensure we have the quantity specified on the CLI
+if [ -z "$1" ]; then ARG_ERR=ERR; fi
+if [ -n "$ARG_ERR" ];
+then
+    echo "Usage: git-graphlive <linecount>"
+    exit
+fi
+
 while :
 do
     clear


### PR DESCRIPTION
Fixed the `git-graphlive` with no argument jarring fail.
