### PR TITLE
added note about histappend for bash to work

### DIFF
--- a/historytailbash
+++ b/historytailbash
@@ -1,5 +1,10 @@
 #!/bin/sh
 
+# The histappend command is generally configured on zsh when setting up
+# and it needs to be placed in your ~/.bashrc when running this script.
+#  shopt -s histappend
+#  export PROMPT_COMMAND="history -a; history -c; history -r; $PROMPT_COMMAND"
+
 #Ensure we have the quantity specified on the CLI
 if [ -z "$2" ]; then ARG_ERR=ERR; fi
 if [ -z "$1" ]; then ARG_ERR=ERR; fi


### PR DESCRIPTION
```
 shopt -s histappend
 export PROMPT_COMMAND="history -a; history -c; history -r; $PROMPT_COMMAND"
```

these are needed in `~/.bashrc` or `~/.bash_profile` for this script to work in bash
