### PR TITLE
Add additional functions to git-completion script

### DIFF
--- a/git-completion
+++ b/git-completion
@@ -76,6 +76,17 @@ __git_ps1 ()
 	fi
 }
 
+# Returns the repo name of the current repository.
+# Produces no output if the cwd is not within a repo
+__git_repo_name()
+{
+	local rn="$(basename `git rev-parse --show-toplevel 2>/dev/null` 2>/dev/null)"
+	if [ -n "$rn" ]; then
+		echo "$rn "
+	fi
+}
+
+
 __gitcomp ()
 {
 	local all c s=$'\n' IFS=' '$'\t'$'\n'

--- a/git-completion
+++ b/git-completion
@@ -86,6 +86,19 @@ __git_repo_name()
 	fi
 }
 
+# Returns the path relative to the repository root, or the full filesystem path
+# if the cwd is not within a repo.
+__git_path_in_repo()
+{
+	# Get the repo name to work out if we're in a repo
+	local rn="$(basename `git rev-parse --show-toplevel 2>/dev/null` 2>/dev/null)"
+	if [ -n "$rn" ]; then
+		local path="$(git rev-parse --show-prefix 2>/dev/null)"
+		echo -n "./$path"
+	else
+		echo `pwd`
+	fi
+}
 
 __gitcomp ()
 {


### PR DESCRIPTION
The changes add two additional functions that can be used to add repository specific information to your prompt - specifically the repository name, and the file path within the respository. This allows you to create useful prompts like this (Where "26-things" is the repo, "master" is the branch", and "images/" is the sub-folder within the repo:

![image](https://cloud.githubusercontent.com/assets/1097338/3177029/4722dec6-ec0b-11e3-8a41-d919bd9489f0.png)

Which all falls back to something sensible when not inside a git repo:

![image](https://cloud.githubusercontent.com/assets/1097338/3177034/5df9c6d2-ec0b-11e3-8ced-e336677abd13.png)

Example PS1:
`export PS1="\[\e[1;31m\]\$(__git_repo_name)\[\e[0m\]\[\e[1;33m\]\$(__git_ps1 \"%s: \")\[\e[0m\]\[\e[1;37m\]\$(__git_path_in_repo)\[\e[0m\] \$ "`
